### PR TITLE
Add db to writeable_dirs list

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -29,7 +29,6 @@ web.main:
   writable_dirs:
     - tmp
     - log
-    - db
 
   # the path to a logfile you want streamed to the nanobox dashboard
   log_watch:

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -11,8 +11,9 @@ deploy.config:
   extra_steps:
     - rake assets:precompile
 
-  transform:
-    - rake db:setup_or_migrate
+  before_live:
+    web.main:
+      - rake db:setup_or_migrate
 
 # add a database
 data.db:
@@ -28,6 +29,7 @@ web.main:
   writable_dirs:
     - tmp
     - log
+    - db
 
   # the path to a logfile you want streamed to the nanobox dashboard
   log_watch:


### PR DESCRIPTION
Permission issues with running rake task `db:setup_or_migrate` as a `before_live` hook. Based on @tylerflint's suggestion added `db` to list of `writeable_dirs`. Moved `db:setup_or_migrate` back, to the docs suggested location, to `before_live:web.main` hook. Deploys successfully. 