### PR TITLE
Minor Update: Instruct user to create PostgreSQL databases and avoid 500 error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
+gem 'rails', '~> 5.0'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,15 +162,14 @@ DEPENDENCIES
   listen (~> 3.0.5)
   pg
   puma (~> 3.0)
-  rails (~> 5.0.0, >= 5.0.0.1)
+  rails (~> 5.0)
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   turbolinks (~> 5)
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console
 
 BUNDLED WITH
-   1.12.5
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ cd nanobox-rails
 # Add a convenient way to access your app from the browser
 nanobox dns add local rails.dev
 
+# Run rake commands as you would normally, with Nanobox
+nanobox run rake db:create
+
 # Run rails as you would normally, with Nanobox
 nanobox run rails s
 ```


### PR DESCRIPTION
## Problem noticed:

Running through the steps provides a 500 error message stating that the database does not exist.

## Solution:

Running `rake db:create` before starting up the server solves this issue.

## Notes

1. Also changed the Gemfile to require rails 5.0 rather then 5.0.0.1 specifically
2. Since there are no migrations both `rake db:setup` and `rake db:migrate` fail