### PR TITLE
Fix puma binding port (boxfile.yml)

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -27,7 +27,7 @@ data.db:
 web.main:
   start:
     nginx: nginx -c /app/config/nginx.conf
-    puma: bundle exec rails s -b 0.0.0.0 -p 8080
+    puma: bundle exec rails s -b 0.0.0.0 -p 3000
 
   # add writable dirs to the web component
   writable_dirs:


### PR DESCRIPTION
Bug:

We cannot start puma on port 8080, NGINX is already running on port
8080.

NGINX actually expects rails/puma to be running on port 3000, as detailed
in our config/nginx.conf config file.